### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/go-chess/security/code-scanning/1](https://github.com/RumenDamyanov/go-chess/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN. The best way to do this is to add the block at the workflow root level, so it applies to all jobs unless overridden. For this workflow, the minimal required permission is likely `contents: read`, since the workflow checks out code, runs tests, and uploads coverage using a secret token (not GITHUB_TOKEN). Add the following block after the workflow name and before the `on:` block:

```yaml
permissions:
  contents: read
```

This change should be made at the top of `.github/workflows/ci.yml`, after the `name: CI` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
