### PR TITLE
Add configurable AI color and chat service integration

### DIFF
--- a/chat/service.go
+++ b/chat/service.go
@@ -1,0 +1,480 @@
+// Package chat provides AI chatbot functionality for chess gameplay interactions.
+// It integrates with the go-chatbot package to provide conversational AI
+// that can discuss chess moves, strategies, and provide friendly commentary.
+package chat
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	gochatbot "github.com/RumenDamyanov/go-chatbot"
+	"github.com/RumenDamyanov/go-chatbot/config"
+	"github.com/RumenDamyanov/go-chatbot/models"
+	"github.com/rumendamyanov/go-chess/engine"
+	"go.uber.org/zap"
+)
+
+// ChatService represents the chess AI chatbot service.
+type ChatService struct {
+	chatbot       *gochatbot.Chatbot
+	config        *config.Config
+	logger        *zap.Logger
+	conversations map[int]*Conversation // gameID -> conversation
+}
+
+// Conversation represents a chat conversation for a specific game.
+type Conversation struct {
+	GameID    int                    `json:"game_id"`
+	Messages  []Message              `json:"messages"`
+	Context   map[string]interface{} `json:"context"`
+	CreatedAt time.Time              `json:"created_at"`
+	UpdatedAt time.Time              `json:"updated_at"`
+}
+
+// Message represents a single chat message.
+type Message struct {
+	ID        string                 `json:"id"`
+	Type      string                 `json:"type"` // "user", "ai", "system"
+	Content   string                 `json:"content"`
+	GameState map[string]interface{} `json:"game_state,omitempty"`
+	Timestamp time.Time              `json:"timestamp"`
+}
+
+// ChatRequest represents a request to the chat service.
+type ChatRequest struct {
+	GameID   int          `json:"game_id"`
+	Message  string       `json:"message"`
+	UserID   string       `json:"user_id,omitempty"`
+	MoveData *MoveContext `json:"move_data,omitempty"`
+}
+
+// ChatResponse represents a response from the chat service.
+type ChatResponse struct {
+	Message     string                 `json:"message"`
+	MessageID   string                 `json:"message_id"`
+	Personality string                 `json:"personality"`
+	GameContext map[string]interface{} `json:"game_context,omitempty"`
+	Suggestions []string               `json:"suggestions,omitempty"`
+	Timestamp   time.Time              `json:"timestamp"`
+}
+
+// MoveContext provides context about recent moves for the AI.
+type MoveContext struct {
+	LastMove      string `json:"last_move"`
+	MoveCount     int    `json:"move_count"`
+	CurrentPlayer string `json:"current_player"`
+	GameStatus    string `json:"game_status"`
+	Position      string `json:"position"` // FEN notation
+}
+
+// NewChatService creates a new chat service instance.
+func NewChatService(logger *zap.Logger) (*ChatService, error) {
+	// Create chatbot configuration
+	cfg := &config.Config{
+		Model: "openai", // Default to OpenAI, can be overridden by env
+		OpenAI: config.OpenAIConfig{
+			APIKey: os.Getenv("OPENAI_API_KEY"),
+			Model:  "gpt-4o-mini", // More cost-effective for chat
+		},
+		Anthropic: config.AnthropicConfig{
+			APIKey: os.Getenv("ANTHROPIC_API_KEY"),
+			Model:  "claude-3-haiku-20240307",
+		},
+		Gemini: config.GeminiConfig{
+			APIKey: os.Getenv("GEMINI_API_KEY"),
+			Model:  "gemini-1.5-flash",
+		},
+		XAI: config.XAIConfig{
+			APIKey: os.Getenv("XAI_API_KEY"),
+			Model:  "grok-1.5",
+		},
+		// Chess-specific prompt configuration
+		Prompt: `You are a friendly AI chess opponent and coach. You are enthusiastic about chess and enjoy discussing games, moves, and strategies. Your personality traits:
+
+- Encouraging and positive, especially towards beginners
+- Knowledgeable about chess openings, tactics, and strategies
+- Able to provide constructive feedback on moves
+- Enjoy making chess-related jokes and observations
+- Respectful and sportsmanlike
+- Can explain chess concepts in simple terms
+
+Guidelines for responses:
+- Keep responses concise (1-3 sentences typically)
+- Focus on chess-related topics
+- Be encouraging about good moves and gentle about mistakes
+- Use chess terminology appropriately
+- Suggest improvements when relevant
+- React to the current game situation
+- Maintain a friendly, conversational tone
+
+You can discuss:
+- Chess moves and their quality
+- Opening theory and strategies
+- Tactical patterns and combinations
+- Endgame techniques
+- General chess improvement tips
+- Chess history and famous games
+- Encouragement and motivation
+
+Avoid:
+- Long lectures unless specifically asked
+- Overly technical analysis unless requested
+- Non-chess topics (politely redirect)
+- Negative or discouraging language
+- Giving away the best moves directly (let them discover)`,
+		Language: "en",
+		Tone:     "friendly",
+		MessageFiltering: config.MessageFilteringConfig{
+			Instructions: []string{
+				"Stay focused on chess-related topics",
+				"Be encouraging and positive",
+				"Avoid spoiling the game by giving direct answers",
+				"Keep responses conversational and fun",
+			},
+			Profanities:        []string{}, // Use default filter
+			AggressionPatterns: []string{}, // Use default filter
+			LinkPattern:        `https?://[\w\.-]+`,
+		},
+	}
+
+	// Detect which AI provider to use based on available API keys
+	if cfg.OpenAI.APIKey != "" {
+		cfg.Model = "openai"
+	} else if cfg.Anthropic.APIKey != "" {
+		cfg.Model = "anthropic"
+	} else if cfg.Gemini.APIKey != "" {
+		cfg.Model = "gemini"
+	} else if cfg.XAI.APIKey != "" {
+		cfg.Model = "xai"
+	} else {
+		// Fallback to free model for development
+		cfg.Model = "free"
+		logger.Warn("No AI API keys found, using free model for chat")
+	}
+
+	// Create model based on configuration
+	model, err := models.NewFromConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AI model: %w", err)
+	}
+
+	// Create chatbot instance
+	chatbot, err := gochatbot.New(cfg, gochatbot.WithModel(model))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create chatbot: %w", err)
+	}
+
+	service := &ChatService{
+		chatbot:       chatbot,
+		config:        cfg,
+		logger:        logger,
+		conversations: make(map[int]*Conversation),
+	}
+
+	logger.Info("Chat service initialized", zap.String("model", cfg.Model))
+	return service, nil
+}
+
+// StartConversation creates a new conversation for a game.
+func (cs *ChatService) StartConversation(gameID int) *Conversation {
+	conversation := &Conversation{
+		GameID:    gameID,
+		Messages:  make([]Message, 0),
+		Context:   make(map[string]interface{}),
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	cs.conversations[gameID] = conversation
+
+	// Add welcome message
+	welcomeMsg := cs.generateWelcomeMessage()
+	cs.addMessage(conversation, "ai", welcomeMsg, nil)
+
+	cs.logger.Info("Started new conversation", zap.Int("game_id", gameID))
+	return conversation
+}
+
+// Chat processes a chat message and returns AI response.
+func (cs *ChatService) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	// Get or create conversation
+	conversation, exists := cs.conversations[req.GameID]
+	if !exists {
+		conversation = cs.StartConversation(req.GameID)
+	}
+
+	// Add user message to conversation
+	messageID := cs.addMessage(conversation, "user", req.Message, req.MoveData)
+
+	// Build context for AI
+	contextualMessage := cs.buildContextualMessage(req.Message, conversation, req.MoveData)
+
+	// Get AI response
+	response, err := cs.chatbot.Ask(ctx, contextualMessage)
+	if err != nil {
+		cs.logger.Error("Failed to get AI response", zap.Error(err))
+		return nil, fmt.Errorf("failed to get AI response: %w", err)
+	}
+
+	// Clean up response (remove any unwanted formatting)
+	cleanResponse := cs.cleanResponse(response)
+
+	// Add AI response to conversation
+	cs.addMessage(conversation, "ai", cleanResponse, nil)
+
+	// Generate suggestions for follow-up
+	suggestions := cs.generateSuggestions(conversation, req.MoveData)
+
+	return &ChatResponse{
+		Message:     cleanResponse,
+		MessageID:   messageID,
+		Personality: "friendly_chess_coach",
+		GameContext: cs.buildGameContext(req.MoveData),
+		Suggestions: suggestions,
+		Timestamp:   time.Now(),
+	}, nil
+}
+
+// ReactToMove generates an AI reaction to a chess move.
+func (cs *ChatService) ReactToMove(ctx context.Context, gameID int, move string, gameState *engine.Game) (*ChatResponse, error) {
+	// Get or create conversation
+	conversation, exists := cs.conversations[gameID]
+	if !exists {
+		conversation = cs.StartConversation(gameID)
+	}
+
+	// Build move context
+	moveData := &MoveContext{
+		LastMove:      move,
+		MoveCount:     len(gameState.MoveHistory()),
+		CurrentPlayer: gameState.ActiveColor().String(),
+		GameStatus:    gameState.Status().String(),
+		Position:      "placeholder-fen", // TODO: Implement FEN export if needed
+	}
+
+	// Generate contextual reaction prompt
+	reactionPrompt := cs.buildMoveReactionPrompt(move, moveData)
+
+	// Get AI reaction
+	reaction, err := cs.chatbot.Ask(ctx, reactionPrompt)
+	if err != nil {
+		cs.logger.Error("Failed to get AI reaction", zap.Error(err))
+		return nil, fmt.Errorf("failed to get AI reaction: %w", err)
+	}
+
+	// Clean response
+	cleanReaction := cs.cleanResponse(reaction)
+
+	// Add reaction to conversation
+	cs.addMessage(conversation, "ai", cleanReaction, moveData)
+
+	return &ChatResponse{
+		Message:     cleanReaction,
+		MessageID:   fmt.Sprintf("reaction_%d_%d", gameID, time.Now().Unix()),
+		Personality: "observant_chess_coach",
+		GameContext: cs.buildGameContext(moveData),
+		Timestamp:   time.Now(),
+	}, nil
+}
+
+// GetConversation returns the conversation for a game.
+func (cs *ChatService) GetConversation(gameID int) *Conversation {
+	return cs.conversations[gameID]
+}
+
+// GetConversationHistory returns the message history for a game.
+func (cs *ChatService) GetConversationHistory(gameID int) []Message {
+	conversation := cs.conversations[gameID]
+	if conversation == nil {
+		return []Message{}
+	}
+	return conversation.Messages
+}
+
+// ClearConversation removes the conversation for a game.
+func (cs *ChatService) ClearConversation(gameID int) {
+	delete(cs.conversations, gameID)
+	cs.logger.Info("Cleared conversation", zap.Int("game_id", gameID))
+}
+
+// Helper methods
+
+func (cs *ChatService) generateWelcomeMessage() string {
+	welcomeMessages := []string{
+		"Hello! I'm your AI chess companion. Ready for a great game? 😊",
+		"Welcome to our chess match! I'm excited to play and chat with you. 🎯",
+		"Hi there! Let's have some fun with chess. Feel free to ask me anything about the game! ♟️",
+		"Greetings, chess friend! I'm here to play, chat, and maybe share some chess wisdom. 🤔",
+		"Hello! Ready to make some great moves? I love discussing chess strategy and tactics! ⚡",
+	}
+
+	// Simple random selection (could be improved with proper randomization)
+	index := int(time.Now().Unix()) % len(welcomeMessages)
+	return welcomeMessages[index]
+}
+
+func (cs *ChatService) addMessage(conversation *Conversation, msgType, content string, moveData *MoveContext) string {
+	messageID := fmt.Sprintf("%s_%d_%d", msgType, conversation.GameID, time.Now().UnixNano())
+
+	var gameState map[string]interface{}
+	if moveData != nil {
+		gameState = map[string]interface{}{
+			"last_move":      moveData.LastMove,
+			"move_count":     moveData.MoveCount,
+			"current_player": moveData.CurrentPlayer,
+			"game_status":    moveData.GameStatus,
+			"position":       moveData.Position,
+		}
+	}
+
+	message := Message{
+		ID:        messageID,
+		Type:      msgType,
+		Content:   content,
+		GameState: gameState,
+		Timestamp: time.Now(),
+	}
+
+	conversation.Messages = append(conversation.Messages, message)
+	conversation.UpdatedAt = time.Now()
+
+	return messageID
+}
+
+func (cs *ChatService) buildContextualMessage(userMessage string, conversation *Conversation, moveData *MoveContext) string {
+	var contextBuilder strings.Builder
+
+	// Add game context if available
+	if moveData != nil {
+		contextBuilder.WriteString(fmt.Sprintf("[Game Context: Move %d, %s to play, Position: %s]",
+			moveData.MoveCount, moveData.CurrentPlayer, moveData.Position[:20]+"..."))
+		if moveData.LastMove != "" {
+			contextBuilder.WriteString(fmt.Sprintf(" [Last move: %s]", moveData.LastMove))
+		}
+		contextBuilder.WriteString("\n\n")
+	}
+
+	// Add recent conversation context (last 3 messages)
+	recentMessages := conversation.Messages
+	if len(recentMessages) > 6 { // Keep last 3 exchanges (6 messages)
+		recentMessages = recentMessages[len(recentMessages)-6:]
+	}
+
+	if len(recentMessages) > 0 {
+		contextBuilder.WriteString("[Recent conversation:\n")
+		for _, msg := range recentMessages {
+			if msg.Type == "user" {
+				contextBuilder.WriteString(fmt.Sprintf("Human: %s\n", msg.Content))
+			} else if msg.Type == "ai" {
+				contextBuilder.WriteString(fmt.Sprintf("Assistant: %s\n", msg.Content))
+			}
+		}
+		contextBuilder.WriteString("]\n\n")
+	}
+
+	// Add current user message
+	contextBuilder.WriteString(fmt.Sprintf("Human: %s", userMessage))
+
+	return contextBuilder.String()
+}
+
+func (cs *ChatService) buildMoveReactionPrompt(move string, moveData *MoveContext) string {
+	return fmt.Sprintf(`[Game Context: Move %d, %s just played %s, Status: %s]
+
+Please give a brief, encouraging reaction to this chess move. Consider:
+- Is this a good opening move, tactical shot, or strategic decision?
+- Should you congratulate, encourage, or gently suggest improvements?
+- Keep it conversational and positive
+- 1-2 sentences maximum
+
+The move played was: %s`,
+		moveData.MoveCount, moveData.CurrentPlayer, move, moveData.GameStatus, move)
+}
+
+func (cs *ChatService) cleanResponse(response string) string {
+	// Remove common AI response artifacts
+	cleaned := strings.TrimSpace(response)
+
+	// Remove any bracketed context that might leak through
+	if strings.HasPrefix(cleaned, "[") {
+		if idx := strings.Index(cleaned, "]"); idx != -1 && idx < 50 {
+			cleaned = strings.TrimSpace(cleaned[idx+1:])
+		}
+	}
+
+	// Remove "Assistant:" or "AI:" prefixes if present
+	prefixes := []string{"Assistant:", "AI:", "Bot:", "Chatbot:"}
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(cleaned, prefix) {
+			cleaned = strings.TrimSpace(cleaned[len(prefix):])
+		}
+	}
+
+	// Ensure response isn't too long for chat (max 280 chars)
+	if len(cleaned) > 280 {
+		// Find last complete sentence within limit
+		if idx := strings.LastIndex(cleaned[:280], "."); idx > 100 {
+			cleaned = cleaned[:idx+1]
+		} else if idx := strings.LastIndex(cleaned[:280], "!"); idx > 100 {
+			cleaned = cleaned[:idx+1]
+		} else if idx := strings.LastIndex(cleaned[:280], "?"); idx > 100 {
+			cleaned = cleaned[:idx+1]
+		} else {
+			cleaned = cleaned[:277] + "..."
+		}
+	}
+
+	return cleaned
+}
+
+func (cs *ChatService) generateSuggestions(conversation *Conversation, moveData *MoveContext) []string {
+	suggestions := []string{
+		"What do you think about this position?",
+		"Any tips for improvement?",
+		"What's your favorite opening?",
+		"How would you rate my play so far?",
+	}
+
+	// Add context-specific suggestions
+	if moveData != nil {
+		if moveData.MoveCount < 10 {
+			suggestions = append(suggestions, "Tell me about this opening")
+		} else if moveData.MoveCount > 30 {
+			suggestions = append(suggestions, "How's my endgame technique?")
+		} else {
+			suggestions = append(suggestions, "Any tactical opportunities here?")
+		}
+	}
+
+	// Return max 3 suggestions
+	if len(suggestions) > 3 {
+		return suggestions[:3]
+	}
+	return suggestions
+}
+
+func (cs *ChatService) buildGameContext(moveData *MoveContext) map[string]interface{} {
+	if moveData == nil {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"move_count":     moveData.MoveCount,
+		"current_player": moveData.CurrentPlayer,
+		"game_status":    moveData.GameStatus,
+		"game_phase":     cs.determineGamePhase(moveData.MoveCount),
+	}
+}
+
+func (cs *ChatService) determineGamePhase(moveCount int) string {
+	if moveCount < 15 {
+		return "opening"
+	} else if moveCount < 35 {
+		return "middlegame"
+	} else {
+		return "endgame"
+	}
+}

--- a/chat/service.go
+++ b/chat/service.go
@@ -349,8 +349,12 @@ func (cs *ChatService) buildContextualMessage(userMessage string, conversation *
 
 	// Add game context if available
 	if moveData != nil {
+		positionPreview := moveData.Position
+		if len(positionPreview) > 20 {
+			positionPreview = positionPreview[:20] + "..."
+		}
 		contextBuilder.WriteString(fmt.Sprintf("[Game Context: Move %d, %s to play, Position: %s]",
-			moveData.MoveCount, moveData.CurrentPlayer, moveData.Position[:20]+"..."))
+			moveData.MoveCount, moveData.CurrentPlayer, positionPreview))
 		if moveData.LastMove != "" {
 			contextBuilder.WriteString(fmt.Sprintf(" [Last move: %s]", moveData.LastMove))
 		}
@@ -430,7 +434,7 @@ func (cs *ChatService) cleanResponse(response string) string {
 	return cleaned
 }
 
-func (cs *ChatService) generateSuggestions(conversation *Conversation, moveData *MoveContext) []string {
+func (cs *ChatService) generateSuggestions(_ *Conversation, moveData *MoveContext) []string {
 	suggestions := []string{
 		"What do you think about this position?",
 		"Any tips for improvement?",

--- a/chat/service_test.go
+++ b/chat/service_test.go
@@ -1,0 +1,184 @@
+package chat
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestNewChatService(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+
+	service, err := NewChatService(logger)
+	if err != nil {
+		t.Errorf("Expected no error creating chat service, got: %v", err)
+	}
+
+	if service == nil {
+		t.Error("Expected chat service to be created, got nil")
+	}
+
+	if service.logger == nil {
+		t.Error("Expected logger to be set in chat service")
+	}
+
+	if service.conversations == nil {
+		t.Error("Expected conversations map to be initialized")
+	}
+}
+
+func TestChatServiceInitialization(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+
+	service, err := NewChatService(logger)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	// Test that the service can be created even without API keys
+	if service.chatbot == nil {
+		t.Error("Expected chatbot to be initialized")
+	}
+
+	if service.config == nil {
+		t.Error("Expected config to be initialized")
+	}
+}
+
+func TestChatRequest(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+
+	service, err := NewChatService(logger)
+	if err != nil {
+		t.Fatalf("Failed to create chat service: %v", err)
+	}
+
+	// Create a chat request
+	req := ChatRequest{
+		GameID:  1,
+		Message: "Hello, what's a good opening move?",
+		UserID:  "test-user",
+	}
+
+	ctx := context.Background()
+
+	// Test chat functionality
+	response, err := service.Chat(ctx, req)
+
+	// The response might fail due to no API keys, but we should handle it gracefully
+	if err != nil {
+		// In test environment without API keys, we expect this might fail
+		// but it should be a handled error, not a panic
+		t.Logf("Chat failed as expected in test environment: %v", err)
+	} else {
+		// If it succeeds (e.g., with a free model), verify response structure
+		if response.Message == "" {
+			t.Error("Expected non-empty message in response")
+		}
+
+		if response.MessageID == "" {
+			t.Error("Expected message ID in response")
+		}
+	}
+}
+
+func TestConversationManagement(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+
+	service, err := NewChatService(logger)
+	if err != nil {
+		t.Fatalf("Failed to create chat service: %v", err)
+	}
+
+	gameID := 123
+
+	// Test that conversations are created for new games
+	if _, exists := service.conversations[gameID]; exists {
+		t.Error("Expected no conversation to exist initially")
+	}
+
+	// Create a conversation (this would happen during a chat request)
+	conv := &Conversation{
+		GameID:   gameID,
+		Messages: []Message{},
+		Context:  make(map[string]interface{}),
+	}
+
+	service.conversations[gameID] = conv
+
+	// Verify conversation was stored
+	if _, exists := service.conversations[gameID]; !exists {
+		t.Error("Expected conversation to be stored")
+	}
+
+	// Test conversation retrieval
+	if storedConv, exists := service.conversations[gameID]; !exists {
+		t.Error("Expected to retrieve stored conversation")
+	} else if storedConv.GameID != gameID {
+		t.Errorf("Expected game ID %d, got %d", gameID, storedConv.GameID)
+	}
+}
+
+func TestMoveContext(t *testing.T) {
+	// Test MoveContext structure
+	moveCtx := &MoveContext{
+		LastMove:      "e2e4",
+		MoveCount:     1,
+		CurrentPlayer: "black",
+		GameStatus:    "active",
+		Position:      "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1",
+	}
+
+	if moveCtx.LastMove != "e2e4" {
+		t.Errorf("Expected last move 'e2e4', got '%s'", moveCtx.LastMove)
+	}
+
+	if moveCtx.MoveCount != 1 {
+		t.Errorf("Expected move count 1, got %d", moveCtx.MoveCount)
+	}
+
+	if moveCtx.CurrentPlayer != "black" {
+		t.Errorf("Expected current player 'black', got '%s'", moveCtx.CurrentPlayer)
+	}
+
+	if moveCtx.GameStatus != "active" {
+		t.Errorf("Expected game status 'active', got '%s'", moveCtx.GameStatus)
+	}
+
+	if len(moveCtx.Position) == 0 {
+		t.Error("Expected position to be set")
+	}
+}
+
+func TestChatRequestValidation(t *testing.T) {
+	// Test ChatRequest structure validation
+	req := ChatRequest{
+		GameID:  1,
+		Message: "Test message",
+		UserID:  "user123",
+		MoveData: &MoveContext{
+			LastMove:   "e2e4",
+			MoveCount:  1,
+			GameStatus: "active",
+		},
+	}
+
+	if req.GameID != 1 {
+		t.Errorf("Expected game ID 1, got %d", req.GameID)
+	}
+
+	if req.Message != "Test message" {
+		t.Errorf("Expected message 'Test message', got '%s'", req.Message)
+	}
+
+	if req.UserID != "user123" {
+		t.Errorf("Expected user ID 'user123', got '%s'", req.UserID)
+	}
+
+	if req.MoveData == nil {
+		t.Error("Expected move data to be set")
+	} else if req.MoveData.LastMove != "e2e4" {
+		t.Errorf("Expected last move 'e2e4', got '%s'", req.MoveData.LastMove)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.6
 
 require (
+	github.com/RumenDamyanov/go-chatbot v1.0.1
 	github.com/gin-gonic/gin v1.10.1
 	github.com/gorilla/websocket v1.5.3
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/RumenDamyanov/go-chatbot v1.0.1 h1:7xAgb5ERL72hWEtwWpLM++yfVU7B0JdfKdo4koOVb5M=
+github.com/RumenDamyanov/go-chatbot v1.0.1/go.mod h1:pr9KpsQsMceW5LXEUmPezVMv7rz3wOrObLhq6b6hV+A=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=
@@ -59,8 +61,9 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=


### PR DESCRIPTION
## 🎯 Overview
This PR adds support for configurable AI color selection and integrates a comprehensive chat service for enhanced chess gameplay experience.

## ✨ New Features

### 🎮 Configurable AI Color
- **AI Color Selection**: Players can now choose whether the AI plays as white or black when creating a new game
- **API Enhancement**: Game creation endpoint accepts `ai_color` parameter (`"white"` or `"black"`)
- **Turn Validation**: AI move endpoint now validates turns based on the configured AI color
- **Game Metadata**: Added tracking of AI color preference and game creation time

### 💬 Chat Service Integration
- **Chess-specific AI Chat**: Integrated `go-chatbot` library for contextual chess conversations
- **Move Reactions**: AI can provide commentary and reactions to specific moves
- **Game Context**: Chat responses are aware of current game state and move history
- **Multiple Chat Modes**: Support for both game-specific chat and general chess conversations

## 🛠️ Technical Changes

### API Endpoints
- **Enhanced**: `POST /api/games` - Now accepts AI color configuration
- **New**: `POST /api/games/:id/ai-hint` - Get AI hints separate from AI moves
- **New**: `POST /api/chat` - General chess chat without game context
- **Enhanced**: `POST /api/games/:id/chat` - Game-specific chat with move context
- **Enhanced**: `POST /api/games/:id/react` - AI reactions to specific moves

### Backend Architecture
- **Game Metadata**: Added `GameMetadata` struct for tracking AI color and timestamps
- **Chat Service**: New `chat/service.go` with comprehensive chat functionality
- **AI Integration**: Enhanced AI move validation based on configured color
- **Response Format**: Added `ai_color` field to `GameResponse`

### Dependencies
- **Added**: `github.com/RumenDamyanov/go-chatbot v1.0.1` for AI chat functionality

## 🔄 Breaking Changes
- Game creation API now supports optional `ai_color` parameter
- AI move endpoint validates turns based on configured AI color instead of assuming black
- Game response format includes new `ai_color` field

## 🧪 Testing
- Tested with both white and black AI configurations
- Verified chat functionality with and without game context
- Validated turn-based gameplay with configurable AI colors

## 📝 Migration Notes
- Existing games will default to AI playing black (backward compatible)
- New games can specify AI color preference
- Chat service gracefully handles missing API keys with appropriate fallbacks

## 🎯 Use Cases
- **Educational**: Allow beginners to play as white for learning openings
- **Analysis**: Switch AI color for position analysis from different perspectives  
- **Interactive**: Enhanced gameplay with AI commentary and move reactions
- **Coaching**: AI can provide hints and explanations during games

## 💡 Future Enhancements
This foundation enables future features like:
- Player skill-based AI difficulty adjustment
- Tournament mode with color randomization
- Move explanation and teaching mode
- Advanced position analysis with AI insights